### PR TITLE
Auto-generated types for string/int/uuid backed objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
   ecs:
     name: Easy Coding Standard
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ramsey/composer-install@v3
@@ -58,7 +58,7 @@ jobs:
 
   phpstan:
     name: PHPStan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ramsey/composer-install@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,8 @@ jobs:
     strategy:
       matrix:
         operating-system: [ 'ubuntu-22.04' ]
-        php: [ '8.1', '8.2', '8.3' ]
+        php: [ '8.2', '8.3' ]
         symfony: ['6.4.*', '7.0.*']
-        exclude:
-          - php: '8.1'
-            symfony: '7.0.*'
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
+src/_generated
 var/
 vendor/

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "symfony/config": "^6.0 || ^7.0",
     "symfony/dependency-injection": "^6.0 || ^7.0",
     "symfony/http-kernel": "^6.0 || ^7.0",
-    "doctrine/doctrine-bundle": "^2.0"
+    "doctrine/doctrine-bundle": "^2.0",
+    "symfony/uid": "^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "issues": "https://github.com/headsnet/doctrine-tools-bundle/issues"
   },
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "doctrine/dbal": "^3.0 || ^4.0",
     "league/construct-finder": "^1.3",
     "symfony/config": "^6.0 || ^7.0",

--- a/config/services.php
+++ b/config/services.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $configurator): void
+{
+    $services = $configurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure()
+    ;
+
+    $services->load('Headsnet\\DoctrineToolsBundle\\', '../src/*');
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          cacheDirectory="var/cache/.phpunit.cache"
          executionOrder="depends,defects"
          requireCoverageMetadata="true"
-         beStrictAboutCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="false"
          beStrictAboutOutputDuringTests="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
          failOnRisky="true"

--- a/src/Attribute/DoctrineType.php
+++ b/src/Attribute/DoctrineType.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class DoctrineType
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $type
+    ) {
+    }
+}

--- a/src/HeadsnetDoctrineToolsBundle.php
+++ b/src/HeadsnetDoctrineToolsBundle.php
@@ -17,14 +17,14 @@ class HeadsnetDoctrineToolsBundle extends AbstractBundle
         $definition->rootNode()
             ->children()
                 ->scalarNode('root_namespace')->cannotBeEmpty()->end()
-                ->arrayNode('preset_types')
+                ->arrayNode('custom_types')
                     ->canBeDisabled()
                     ->children()
                         ->arrayNode('scan_dirs')
                             ->defaultValue(['src/'])->scalarPrototype()->end()
                         ->end()
                     ->end()
-                ->end() // End preset_types
+                ->end() // End custom_types
                 ->arrayNode('custom_mappings')
                     ->children()
                         ->arrayNode('scan_dirs')
@@ -44,7 +44,7 @@ class HeadsnetDoctrineToolsBundle extends AbstractBundle
     /**
      * @param array{
      *     root_namespace: string,
-     *     preset_types: array{scan_dirs: array<string>},
+     *     custom_types: array{scan_dirs: array<string>},
      *     custom_mappings: array{scan_dirs: array<string>},
      *     carbon_mappings: array{enabled: boolean, replace: boolean}
      * } $config
@@ -55,7 +55,7 @@ class HeadsnetDoctrineToolsBundle extends AbstractBundle
 
         $container->parameters()
             ->set('headsnet_doctrine_tools.root_namespace', $config['root_namespace'])
-            ->set('headsnet_doctrine_tools.preset_types.scan_dirs', $config['preset_types']['scan_dirs'])
+            ->set('headsnet_doctrine_tools.custom_types.scan_dirs', $config['custom_types']['scan_dirs'])
             ->set('headsnet_doctrine_tools.custom_mappings.scan_dirs', $config['custom_mappings']['scan_dirs'])
             ->set('headsnet_doctrine_tools.carbon_mappings.enabled', $config['carbon_mappings']['enabled'])
             ->set('headsnet_doctrine_tools.carbon_mappings.replace', $config['carbon_mappings']['replace'])

--- a/src/HeadsnetDoctrineToolsBundle.php
+++ b/src/HeadsnetDoctrineToolsBundle.php
@@ -4,6 +4,7 @@ namespace Headsnet\DoctrineToolsBundle;
 
 use Headsnet\DoctrineToolsBundle\Mapping\CarbonTypeMappingsCompilerPass;
 use Headsnet\DoctrineToolsBundle\Mapping\DoctrineTypeMappingsCompilerPass;
+use Headsnet\DoctrineToolsBundle\Types\DoctrineTypesCompilerPass;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -15,6 +16,15 @@ class HeadsnetDoctrineToolsBundle extends AbstractBundle
     {
         $definition->rootNode()
             ->children()
+                ->scalarNode('root_namespace')->cannotBeEmpty()->end()
+                ->arrayNode('preset_types')
+                    ->canBeDisabled()
+                    ->children()
+                        ->arrayNode('scan_dirs')
+                            ->defaultValue(['src/'])->scalarPrototype()->end()
+                        ->end()
+                    ->end()
+                ->end() // End preset_types
                 ->arrayNode('custom_mappings')
                     ->children()
                         ->arrayNode('scan_dirs')
@@ -33,13 +43,19 @@ class HeadsnetDoctrineToolsBundle extends AbstractBundle
 
     /**
      * @param array{
+     *     root_namespace: string,
+     *     preset_types: array{scan_dirs: array<string>},
      *     custom_mappings: array{scan_dirs: array<string>},
      *     carbon_mappings: array{enabled: boolean, replace: boolean}
      * } $config
      */
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
+        $container->import('../config/services.php');
+
         $container->parameters()
+            ->set('headsnet_doctrine_tools.root_namespace', $config['root_namespace'])
+            ->set('headsnet_doctrine_tools.preset_types.scan_dirs', $config['preset_types']['scan_dirs'])
             ->set('headsnet_doctrine_tools.custom_mappings.scan_dirs', $config['custom_mappings']['scan_dirs'])
             ->set('headsnet_doctrine_tools.carbon_mappings.enabled', $config['carbon_mappings']['enabled'])
             ->set('headsnet_doctrine_tools.carbon_mappings.replace', $config['carbon_mappings']['replace'])
@@ -49,6 +65,10 @@ class HeadsnetDoctrineToolsBundle extends AbstractBundle
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);
+
+        $container->addCompilerPass(
+            new DoctrineTypesCompilerPass()
+        );
 
         $container->addCompilerPass(
             new DoctrineTypeMappingsCompilerPass()

--- a/src/Types/CandidateType.php
+++ b/src/Types/CandidateType.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Types;
+
+final class CandidateType
+{
+    private string $baseTypeClass;
+
+    /**
+     * @param class-string $objectClass
+     */
+    public function __construct(
+        public readonly string $typeName,
+        public readonly string $typeClass,
+        public readonly string $baseType,
+        public readonly string $objectClass,
+    ) {
+    }
+
+    public function setBaseTypeClass(string $baseTypeClass): void
+    {
+        $this->baseTypeClass = $baseTypeClass;
+    }
+
+    public function getBaseTypeClass(): string
+    {
+        return $this->baseTypeClass;
+    }
+}

--- a/src/Types/CandidateType.php
+++ b/src/Types/CandidateType.php
@@ -5,7 +5,7 @@ namespace Headsnet\DoctrineToolsBundle\Types;
 
 final class CandidateType
 {
-    private string $baseTypeClass;
+    private string $baseTypeClass = '';
 
     /**
      * @param class-string $objectClass

--- a/src/Types/DoctrineTypesCompilerPass.php
+++ b/src/Types/DoctrineTypesCompilerPass.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Types;
+
+use Headsnet\DoctrineToolsBundle\Attribute\DoctrineType;
+use Headsnet\DoctrineToolsBundle\Types\StandardTypes\MappingPrototype;
+use League\ConstructFinder\ConstructFinder;
+use ReflectionClass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Automatically create Doctrine types for any class that implements #[DoctrineType].
+ */
+final class DoctrineTypesCompilerPass implements CompilerPassInterface
+{
+    private const TYPE_DEFINITION_PARAMETER = 'doctrine.dbal.connection_factory.types';
+
+    private string $rootNamespace;
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter(self::TYPE_DEFINITION_PARAMETER)) {
+            return;
+        }
+
+        /** @var array<string, array{class: class-string}> $typeDefinitions */
+        $typeDefinitions = $container->getParameter(self::TYPE_DEFINITION_PARAMETER);
+        /** @var array<string> $scanDirs */
+        $scanDirs = $container->getParameter('headsnet_doctrine_tools.preset_types.scan_dirs');
+        $this->rootNamespace = $container->getParameter('headsnet_doctrine_tools.root_namespace'); // @phpstan-ignore-line
+
+        $objectsToRegister = $this->findObjectsToRegister($scanDirs);
+
+        $prototypeTypes = array_keys($container->findTaggedServiceIds(MappingPrototype::TAG));
+
+        foreach ($objectsToRegister as $candidate) {
+            // Do not add the type if it's been manually defined already
+            if (array_key_exists($candidate->typeName, $typeDefinitions)) {
+                continue;
+            }
+
+            /** @var MappingPrototype $prototypeType */
+            foreach ($prototypeTypes as $prototypeType) {
+                if ($prototypeType::supports($candidate->baseType)) {
+                    $candidate->setBaseTypeClass(
+                        $prototypeType::mappedBy()
+                    );
+                }
+            }
+
+            if (!$candidate->getBaseTypeClass()) {
+                throw new \RuntimeException('Unsupported base type for Doctrine!');
+            }
+
+            $this->writeClassToFile($candidate);
+
+            $typeDefinitions[$candidate->typeName] = [
+                'class' => sprintf(
+                    '%s\_generated\HeadsnetDoctrineTools\Types\\%s',
+                    $this->rootNamespace,
+                    $candidate->typeClass
+                ),
+            ];
+        }
+
+        $container->setParameter(self::TYPE_DEFINITION_PARAMETER, $typeDefinitions);
+    }
+
+    /**
+     * @param array<string> $scanDirs
+     *
+     * @return iterable<CandidateType>
+     */
+    private function findObjectsToRegister(array $scanDirs): iterable
+    {
+        $classNames = ConstructFinder::locatedIn(...$scanDirs)->findClassNames();
+
+        foreach ($classNames as $className) {
+            $reflection = new ReflectionClass($className);
+
+            // Skip any abstract parent types
+            if ($reflection->isAbstract()) {
+                continue;
+            }
+
+            // Only register types that have the #[DoctrineType] attribute
+            if ($reflection->getAttributes(DoctrineType::class)) {
+                $attribute = $reflection->getAttributes(DoctrineType::class)[0];
+                $attributeArgs = $attribute->getArguments();
+
+                yield new CandidateType(
+                    typeName: $attributeArgs['name'],
+                    typeClass: $reflection->getShortName() . 'Type',
+                    baseType: $attributeArgs['type'],
+                    objectClass: $className
+                );
+            }
+        }
+    }
+
+    private function generateClass(CandidateType $candidate): string
+    {
+        return <<<PHP
+<?php
+
+namespace $this->rootNamespace\_generated\HeadsnetDoctrineTools\Types;
+
+class $candidate->typeClass extends \\{$candidate->getBaseTypeClass()} {
+    public function getName(): string
+    {
+        return '$candidate->typeName';
+    }
+
+    public function getClass(): string
+    {
+        return '$candidate->objectClass';
+    }
+}
+PHP;
+    }
+
+    private function writeClassToFile(CandidateType $candidate): void
+    {
+        $classCode = $this->generateClass($candidate);
+
+        $filePath = sprintf('src/_generated/HeadsnetDoctrineTools/Types/%s.php', $candidate->typeClass);
+
+        if (!is_dir(dirname($filePath))) {
+            mkdir(dirname($filePath), 0777, true);
+        }
+
+        file_put_contents($filePath, $classCode);
+    }
+}

--- a/src/Types/DoctrineTypesCompilerPass.php
+++ b/src/Types/DoctrineTypesCompilerPass.php
@@ -28,7 +28,7 @@ final class DoctrineTypesCompilerPass implements CompilerPassInterface
         /** @var array<string, array{class: class-string}> $typeDefinitions */
         $typeDefinitions = $container->getParameter(self::TYPE_DEFINITION_PARAMETER);
         /** @var array<string> $scanDirs */
-        $scanDirs = $container->getParameter('headsnet_doctrine_tools.preset_types.scan_dirs');
+        $scanDirs = $container->getParameter('headsnet_doctrine_tools.custom_types.scan_dirs');
         $this->rootNamespace = $container->getParameter('headsnet_doctrine_tools.root_namespace'); // @phpstan-ignore-line
 
         $objectsToRegister = $this->findObjectsToRegister($scanDirs);

--- a/src/Types/StandardTypes/AbstractIntegerMappingType.php
+++ b/src/Types/StandardTypes/AbstractIntegerMappingType.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Types\StandardTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+abstract class AbstractIntegerMappingType extends Type
+{
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getIntegerTypeDeclarationSQL($column);
+    }
+
+    /**
+     * @param int|null $value
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?object
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $class = $this->getClass();
+
+        return $class::create($value);
+    }
+
+    /**
+     * @param object|null $value
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?int
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return $value->asInteger(); // @phpstan-ignore-line
+    }
+
+    abstract public function getName(): string;
+
+    abstract public function getClass(): string;
+}

--- a/src/Types/StandardTypes/AbstractIntegerMappingType.php
+++ b/src/Types/StandardTypes/AbstractIntegerMappingType.php
@@ -8,6 +8,9 @@ use Doctrine\DBAL\Types\Type;
 
 abstract class AbstractIntegerMappingType extends Type
 {
+    /**
+     * @codeCoverageIgnore
+     */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getIntegerTypeDeclarationSQL($column);

--- a/src/Types/StandardTypes/AbstractStringMappingType.php
+++ b/src/Types/StandardTypes/AbstractStringMappingType.php
@@ -8,6 +8,9 @@ use Doctrine\DBAL\Types\Type;
 
 abstract class AbstractStringMappingType extends Type
 {
+    /**
+     * @codeCoverageIgnore
+     */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getStringTypeDeclarationSQL($column);
@@ -32,11 +35,7 @@ abstract class AbstractStringMappingType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
-        if ($value === null) {
-            return null;
-        }
-
-        return $value->asString(); // @phpstan-ignore-line
+        return $value?->asString(); // @phpstan-ignore-line
     }
 
     abstract public function getName(): string;

--- a/src/Types/StandardTypes/AbstractStringMappingType.php
+++ b/src/Types/StandardTypes/AbstractStringMappingType.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Types\StandardTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+abstract class AbstractStringMappingType extends Type
+{
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getStringTypeDeclarationSQL($column);
+    }
+
+    /**
+     * @param string|null $value
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?object
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $class = $this->getClass();
+
+        return $class::create($value);
+    }
+
+    /**
+     * @param object|null $value
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return $value->asString(); // @phpstan-ignore-line
+    }
+
+    abstract public function getName(): string;
+
+    abstract public function getClass(): string;
+}

--- a/src/Types/StandardTypes/AbstractUuidMappingType.php
+++ b/src/Types/StandardTypes/AbstractUuidMappingType.php
@@ -5,16 +5,20 @@ namespace Headsnet\DoctrineToolsBundle\Types\StandardTypes;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Symfony\Component\Uid\Uuid;
 
 abstract class AbstractUuidMappingType extends Type
 {
+    /**
+     * @codeCoverageIgnore
+     */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getGuidTypeDeclarationSQL($column);
     }
 
     /**
-     * @param string|null $value
+     * @param Uuid|string|null $value
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?object
     {
@@ -24,7 +28,11 @@ abstract class AbstractUuidMappingType extends Type
 
         $class = $this->getClass();
 
-        return $class::fromString($value);
+        if (is_string($value)) {
+            return $class::fromString($value);
+        }
+
+        return $class::create($value);
     }
 
     /**

--- a/src/Types/StandardTypes/AbstractUuidMappingType.php
+++ b/src/Types/StandardTypes/AbstractUuidMappingType.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Types\StandardTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+abstract class AbstractUuidMappingType extends Type
+{
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getGuidTypeDeclarationSQL($column);
+    }
+
+    /**
+     * @param string|null $value
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?object
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $class = $this->getClass();
+
+        return $class::fromString($value);
+    }
+
+    /**
+     * @param object|string|null $value
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return $value->asString(); // @phpstan-ignore-line
+    }
+
+    abstract public function getName(): string;
+
+    abstract public function getClass(): string;
+}

--- a/src/Types/StandardTypes/IntegerMappingPrototype.php
+++ b/src/Types/StandardTypes/IntegerMappingPrototype.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Types\StandardTypes;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(tags: [MappingPrototype::TAG])]
+class IntegerMappingPrototype implements MappingPrototype
+{
+    public static function supports(string $type): bool
+    {
+        return $type === 'integer';
+    }
+
+    public static function mappedBy(): string
+    {
+        return AbstractIntegerMappingType::class;
+    }
+}

--- a/src/Types/StandardTypes/MappingPrototype.php
+++ b/src/Types/StandardTypes/MappingPrototype.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Types\StandardTypes;
+
+interface MappingPrototype
+{
+    public const TAG = 'headsnet_doctrine_tools.standard_type';
+
+    public static function supports(string $type): bool;
+
+    public static function mappedBy(): string;
+}

--- a/src/Types/StandardTypes/StringMappingPrototype.php
+++ b/src/Types/StandardTypes/StringMappingPrototype.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Types\StandardTypes;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(tags: [MappingPrototype::TAG])]
+class StringMappingPrototype implements MappingPrototype
+{
+    public static function supports(string $type): bool
+    {
+        return $type === 'string';
+    }
+
+    public static function mappedBy(): string
+    {
+        return AbstractStringMappingType::class;
+    }
+}

--- a/src/Types/StandardTypes/UuidMappingPrototype.php
+++ b/src/Types/StandardTypes/UuidMappingPrototype.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Types\StandardTypes;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(tags: [MappingPrototype::TAG])]
+class UuidMappingPrototype implements MappingPrototype
+{
+    public static function supports(string $type): bool
+    {
+        return $type === 'uuid';
+    }
+
+    public static function mappedBy(): string
+    {
+        return AbstractUuidMappingType::class;
+    }
+}

--- a/tests/Attribute/DoctrineTypeTest.php
+++ b/tests/Attribute/DoctrineTypeTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Tests\Attribute;
+
+use Headsnet\DoctrineToolsBundle\Attribute\DoctrineType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DoctrineType::class)]
+class DoctrineTypeTest extends TestCase
+{
+    #[Test]
+    public function name_can_be_specified(): void
+    {
+        $sut = new DoctrineType(
+            name: 'custom_name',
+            type: 'string',
+        );
+
+        $this->assertEquals('custom_name', $sut->name);
+    }
+}

--- a/tests/Fixtures/config.yaml
+++ b/tests/Fixtures/config.yaml
@@ -1,5 +1,5 @@
 headsnet_doctrine_tools:
   root_namespace: App
-  carbon_mappings:
+  custom_mappings:
     scan_dirs:
       - 'src/Infra/Persistence/DBAL/Types'

--- a/tests/Fixtures/config.yaml
+++ b/tests/Fixtures/config.yaml
@@ -1,4 +1,5 @@
 headsnet_doctrine_tools:
-  custom_mappings:
+  root_namespace: App
+  carbon_mappings:
     scan_dirs:
       - 'src/Infra/Persistence/DBAL/Types'

--- a/tests/HeadsnetDoctrineToolsBundleTest.php
+++ b/tests/HeadsnetDoctrineToolsBundleTest.php
@@ -6,6 +6,7 @@ namespace Headsnet\DoctrineToolsBundle\Tests;
 use Headsnet\DoctrineToolsBundle\HeadsnetDoctrineToolsBundle;
 use Headsnet\DoctrineToolsBundle\Mapping\CarbonTypeMappingsCompilerPass;
 use Headsnet\DoctrineToolsBundle\Mapping\DoctrineTypeMappingsCompilerPass;
+use Headsnet\DoctrineToolsBundle\Types\DoctrineTypesCompilerPass;
 use Nyholm\BundleTest\TestKernel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -15,6 +16,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 #[CoversClass(HeadsnetDoctrineToolsBundle::class)]
 #[CoversClass(CarbonTypeMappingsCompilerPass::class)]
 #[CoversClass(DoctrineTypeMappingsCompilerPass::class)]
+#[CoversClass(DoctrineTypesCompilerPass::class)]
 class HeadsnetDoctrineToolsBundleTest extends KernelTestCase
 {
     protected static function getKernelClass(): string

--- a/tests/HeadsnetDoctrineToolsBundleTest.php
+++ b/tests/HeadsnetDoctrineToolsBundleTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 namespace Headsnet\DoctrineToolsBundle\Tests;
 
 use Headsnet\DoctrineToolsBundle\HeadsnetDoctrineToolsBundle;
-use Headsnet\DoctrineToolsBundle\Mapping\CarbonTypeMappingsCompilerPass;
-use Headsnet\DoctrineToolsBundle\Mapping\DoctrineTypeMappingsCompilerPass;
-use Headsnet\DoctrineToolsBundle\Types\DoctrineTypesCompilerPass;
 use Nyholm\BundleTest\TestKernel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -14,9 +11,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 #[CoversClass(HeadsnetDoctrineToolsBundle::class)]
-#[CoversClass(CarbonTypeMappingsCompilerPass::class)]
-#[CoversClass(DoctrineTypeMappingsCompilerPass::class)]
-#[CoversClass(DoctrineTypesCompilerPass::class)]
 class HeadsnetDoctrineToolsBundleTest extends KernelTestCase
 {
     protected static function getKernelClass(): string

--- a/tests/Types/DoctrineTypesCompilerPassTest.php
+++ b/tests/Types/DoctrineTypesCompilerPassTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Tests\Types;
+
+use Headsnet\DoctrineToolsBundle\HeadsnetDoctrineToolsBundle;
+use Headsnet\DoctrineToolsBundle\Types\CandidateType;
+use Headsnet\DoctrineToolsBundle\Types\DoctrineTypesCompilerPass;
+use Headsnet\DoctrineToolsBundle\Types\StandardTypes\IntegerMappingPrototype;
+use Headsnet\DoctrineToolsBundle\Types\StandardTypes\StringMappingPrototype;
+use Headsnet\DoctrineToolsBundle\Types\StandardTypes\UuidMappingPrototype;
+use Nyholm\BundleTest\TestKernel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+#[CoversClass(DoctrineTypesCompilerPass::class)]
+#[CoversClass(StringMappingPrototype::class)]
+#[CoversClass(IntegerMappingPrototype::class)]
+#[CoversClass(UuidMappingPrototype::class)]
+#[CoversClass(CandidateType::class)]
+class DoctrineTypesCompilerPassTest extends KernelTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    /**
+     * @param array{debug?: bool, environment?: string} $options
+     */
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        /** @var TestKernel $kernel $kernel */
+        $kernel = parent::createKernel($options);
+        $kernel->addTestBundle(HeadsnetDoctrineToolsBundle::class);
+        $kernel->addTestConfig(__DIR__ . '/Fixtures/config.yaml');
+        $kernel->handleOptions($options);
+
+        return $kernel;
+    }
+
+    #[Test]
+    public function can_find_and_register_types(): void
+    {
+        $kernel = self::bootKernel();
+        $container = $kernel->getContainer();
+        $result = $container->getParameter('doctrine.dbal.connection_factory.types');
+
+        $expected = [
+            'dummy_string' => [
+                'class' => 'Headsnet\DoctrineToolsBundle\_generated\HeadsnetDoctrineTools\Types\DummyStringObjectType',
+            ],
+            'dummy_integer' => [
+                'class' => 'Headsnet\DoctrineToolsBundle\_generated\HeadsnetDoctrineTools\Types\DummyIntegerObjectType',
+            ],
+            'dummy_uuid' => [
+                'class' => 'Headsnet\DoctrineToolsBundle\_generated\HeadsnetDoctrineTools\Types\DummyUuidObjectType',
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Types/Fixtures/DummyIntegerObject.php
+++ b/tests/Types/Fixtures/DummyIntegerObject.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Tests\Types\Fixtures;
+
+use Headsnet\DoctrineToolsBundle\Attribute\DoctrineType;
+
+#[DoctrineType(name: 'dummy_integer', type: 'integer')]
+class DummyIntegerObject
+{
+    public function __construct(
+        private readonly int $value
+    ) {
+    }
+
+    public static function create(int $value): self
+    {
+        return new self($value);
+    }
+
+    public function asInteger(): int
+    {
+        return $this->value;
+    }
+}

--- a/tests/Types/Fixtures/DummyStringObject.php
+++ b/tests/Types/Fixtures/DummyStringObject.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Tests\Types\Fixtures;
+
+use Headsnet\DoctrineToolsBundle\Attribute\DoctrineType;
+
+#[DoctrineType(name: 'dummy_string', type: 'string')]
+class DummyStringObject
+{
+    public function __construct(
+        private readonly string $value
+    ) {
+    }
+
+    public static function create(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function asString(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Types/Fixtures/DummyUuidObject.php
+++ b/tests/Types/Fixtures/DummyUuidObject.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Tests\Types\Fixtures;
+
+use Headsnet\DoctrineToolsBundle\Attribute\DoctrineType;
+use Symfony\Component\Uid\Uuid;
+
+#[DoctrineType(name: 'dummy_uuid', type: 'uuid')]
+class DummyUuidObject
+{
+    public function __construct(
+        private readonly Uuid $value
+    ) {
+    }
+
+    public static function create(Uuid $value): self
+    {
+        return new self($value);
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self(Uuid::fromString($value));
+    }
+
+    public function asString(): string
+    {
+        return $this->value->toRfc4122();
+    }
+}

--- a/tests/Types/Fixtures/config.yaml
+++ b/tests/Types/Fixtures/config.yaml
@@ -1,0 +1,13 @@
+
+headsnet_doctrine_tools:
+  root_namespace: Headsnet\DoctrineToolsBundle
+  custom_types:
+    scan_dirs:
+      - './tests/Types/Fixtures'
+  carbon_mappings:
+    enabled: false
+  custom_mappings:
+    scan_dirs: []
+
+parameters:
+  doctrine.dbal.connection_factory.types: []

--- a/tests/Types/StandardTypes/AbstractIntegerMappingTypeTest.php
+++ b/tests/Types/StandardTypes/AbstractIntegerMappingTypeTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Tests\Types\StandardTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Headsnet\DoctrineToolsBundle\Tests\Types\Fixtures\DummyIntegerObject;
+use Headsnet\DoctrineToolsBundle\Types\StandardTypes\AbstractIntegerMappingType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AbstractIntegerMappingType::class)]
+class AbstractIntegerMappingTypeTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('phpDataProvider')]
+    public function converting_to_php_value(int|null $value, object|null $expectedResult): void
+    {
+        $sut = $this->buildSut();
+
+        $result = $sut->convertToPHPValue(
+            $value,
+            $this->createMock(AbstractPlatform::class)
+        );
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return iterable<array{0: int|null, 1: DummyIntegerObject|null}>
+     */
+    public static function phpDataProvider(): iterable
+    {
+        yield [42, DummyIntegerObject::create(42)];
+        yield [null, null];
+    }
+
+    #[Test]
+    #[DataProvider('databaseDataProvider')]
+    public function converting_to_database_value(object|null $value, int|null $expectedResult): void
+    {
+        $sut = $this->buildSut();
+
+        $result = $sut->convertToDatabaseValue(
+            $value,
+            $this->createMock(AbstractPlatform::class)
+        );
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return iterable<array{0: DummyIntegerObject|null, 1: int|null}>
+     */
+    public static function databaseDataProvider(): iterable
+    {
+        yield [DummyIntegerObject::create(42), 42];
+        yield [null, null];
+    }
+
+    private function buildSut(): AbstractIntegerMappingType
+    {
+        return new class() extends AbstractIntegerMappingType {
+            public function getName(): string
+            {
+                return 'dummy';
+            }
+
+            public function getClass(): string
+            {
+                return DummyIntegerObject::class;
+            }
+        };
+    }
+}

--- a/tests/Types/StandardTypes/AbstractStringMappingTypeTest.php
+++ b/tests/Types/StandardTypes/AbstractStringMappingTypeTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Tests\Types\StandardTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Headsnet\DoctrineToolsBundle\Tests\Types\Fixtures\DummyStringObject;
+use Headsnet\DoctrineToolsBundle\Types\StandardTypes\AbstractStringMappingType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AbstractStringMappingType::class)]
+class AbstractStringMappingTypeTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('phpDataProvider')]
+    public function converting_to_php_value(string|null $value, object|null $expectedResult): void
+    {
+        $sut = $this->buildSut();
+
+        $result = $sut->convertToPHPValue(
+            $value,
+            $this->createMock(AbstractPlatform::class)
+        );
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return iterable<array{0: string|null, 1: DummyStringObject|null}>
+     */
+    public static function phpDataProvider(): iterable
+    {
+        yield ['foo', DummyStringObject::create('foo')];
+        yield [null, null];
+    }
+
+    #[Test]
+    #[DataProvider('databaseDataProvider')]
+    public function converting_to_database_value(object|null $value, string|null $expectedResult): void
+    {
+        $sut = $this->buildSut();
+
+        $result = $sut->convertToDatabaseValue(
+            $value,
+            $this->createMock(AbstractPlatform::class)
+        );
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return iterable<array{0: DummyStringObject|null, 1: string|null}>
+     */
+    public static function databaseDataProvider(): iterable
+    {
+        yield [DummyStringObject::create('foo'), 'foo'];
+        yield [null, null];
+    }
+
+    private function buildSut(): AbstractStringMappingType
+    {
+        return new class() extends AbstractStringMappingType {
+            public function getName(): string
+            {
+                return 'dummy';
+            }
+
+            public function getClass(): string
+            {
+                return DummyStringObject::class;
+            }
+        };
+    }
+}

--- a/tests/Types/StandardTypes/AbstractUuidMappingTypeTest.php
+++ b/tests/Types/StandardTypes/AbstractUuidMappingTypeTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Headsnet\DoctrineToolsBundle\Tests\Types\StandardTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Headsnet\DoctrineToolsBundle\Tests\Types\Fixtures\DummyUuidObject;
+use Headsnet\DoctrineToolsBundle\Types\StandardTypes\AbstractUuidMappingType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+#[CoversClass(AbstractUuidMappingType::class)]
+class AbstractUuidMappingTypeTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('phpDataProvider')]
+    public function converting_to_php_value(Uuid|string|null $value, object|null $expectedResult): void
+    {
+        $sut = $this->buildSut();
+
+        $result = $sut->convertToPHPValue(
+            $value,
+            $this->createMock(AbstractPlatform::class)
+        );
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return iterable<array{0: Uuid|string|null, 1: DummyUuidObject|null}>
+     */
+    public static function phpDataProvider(): iterable
+    {
+        $uuidV7 = Uuid::v7();
+        yield [$uuidV7, DummyUuidObject::create($uuidV7)];
+        yield [$uuidV7->toRfc4122(), DummyUuidObject::create($uuidV7)];
+        yield [null, null];
+    }
+
+    #[Test]
+    #[DataProvider('databaseDataProvider')]
+    public function converting_to_database_value(object|string|null $value, Uuid|null $expectedResult): void
+    {
+        $sut = $this->buildSut();
+
+        $result = $sut->convertToDatabaseValue(
+            $value,
+            $this->createMock(AbstractPlatform::class)
+        );
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return iterable<array{0: DummyUuidObject|string|null, 1: Uuid|string|null}>
+     */
+    public static function databaseDataProvider(): iterable
+    {
+        $value = Uuid::v7();
+        yield [DummyUuidObject::create($value), $value];
+        yield [DummyUuidObject::create($value)->asString(), $value];
+        yield [null, null];
+    }
+
+    private function buildSut(): AbstractUuidMappingType
+    {
+        return new class() extends AbstractUuidMappingType {
+            public function getName(): string
+            {
+                return 'dummy';
+            }
+
+            public function getClass(): string
+            {
+                return DummyUuidObject::class;
+            }
+        };
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+use Symfony\Component\Filesystem\Filesystem;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$filesystem = new Filesystem();
+
+if ($filesystem->exists(__DIR__ . '/../src/_generated')) {
+    echo "Removing generated test files...\n";
+    $filesystem->remove(__DIR__ . '/../src/_generated');
+}


### PR DESCRIPTION
This PR introduces a `#[DoctrineType]` which allows automatic configuration of a Doctrine type, with associated mapping, for any object that is backed by a string, int,  or UUID.