### PR TITLE
fix: Fix generation of "_generated" directory path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
   "config": {
     "allow-plugins": {
       "phpstan/extension-installer": true
+    },
+    "audit": {
+      "block-insecure": false
     }
   }
 }


### PR DESCRIPTION
This was not being anchored to the project root, so when clearing the cache in the terminal, the _generated directory was created in the correct location, but when this was triggered from the front controller it would place the src/_generated directory inside the public/ directory which is not correct.

This commit simply defines the project root and adds this to the path as as prefix.